### PR TITLE
Create endpoint for post picture

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "ts-node": "^9.0.0"

--- a/src/api/v1/controllers.ts
+++ b/src/api/v1/controllers.ts
@@ -1,20 +1,25 @@
+// V1 OF ts-lmu-backend API CONTROLLERS
+
 import { Router } from "express";
 export const apiV1Controllers: Router = Router();
 
 import { STATUSES } from "../../utils/httpStatuses";
 
-// CONTROLLERS
+// CONTROLLERS IMPORT
 import {
   postPictureController,
+  postPictureUrl,
   postPictureValidationMiddleware,
 } from "./postPictureController";
 
+// API TEST SIMPLE CONTROLLER
 apiV1Controllers.get("/test", (req, res): void => {
   res.status(STATUSES.SUCCESS.code).json(STATUSES.SUCCESS.message);
 });
 
+// CONTROLLERS DECLARATIONS
 apiV1Controllers.post(
-  "/postPicture/:format/:w/:h",
+  postPictureUrl,
   postPictureValidationMiddleware,
   postPictureController
 );

--- a/src/api/v1/controllers.ts
+++ b/src/api/v1/controllers.ts
@@ -1,8 +1,20 @@
 import { Router } from "express";
 export const apiV1Controllers: Router = Router();
 
-const STATUS_SUCCESSS = 200;
+import { STATUSES } from "../../utils/httpStatuses";
+
+// CONTROLLERS
+import {
+  postPictureController,
+  postPictureValidationMiddleware,
+} from "./postPictureController";
 
 apiV1Controllers.get("/test", (req, res): void => {
-  res.status(STATUS_SUCCESSS).send("API TEST OK");
+  res.status(STATUSES.SUCCESS.code).json(STATUSES.SUCCESS.message);
 });
+
+apiV1Controllers.post(
+  "/postPicture/:format/:w/:h",
+  postPictureValidationMiddleware,
+  postPictureController
+);

--- a/src/api/v1/postPictureController.ts
+++ b/src/api/v1/postPictureController.ts
@@ -1,0 +1,48 @@
+import { STATUSES } from "../../utils/httpStatuses";
+
+export function postPictureController(req, res) {
+  const params = req.params.parsed;
+
+  res.status(STATUSES.SUCCESS.code).json(params);
+}
+
+export function postPictureValidationMiddleware(req, res, next) {
+  const body = req.body;
+
+  const format = req.params.format;
+  const width = parseInt(req.params.w, 10);
+  const height = parseInt(req.params.h, 10);
+
+  if (format !== "png" && format !== "jpg") {
+    res
+      .status(STATUSES.BAD_REQUEST.code)
+      .send(
+        `${STATUSES.BAD_REQUEST.message} | :format should be 'png' or 'jpg'`
+      );
+  } else if (!width && width > 0 && width < 1920) {
+    res
+      .status(STATUSES.BAD_REQUEST.code)
+      .send(
+        `${STATUSES.BAD_REQUEST.message} | :w should be INT higher then 0 and lower then 1920`
+      );
+  } else if (!height && height > 0 && height < 1080) {
+    res
+      .status(STATUSES.BAD_REQUEST.code)
+      .send(
+        `${STATUSES.BAD_REQUEST.message} | :h should be INT higher then 0 and lower then 1080`
+      );
+  } else if (!(typeof body === "object" && typeof body.image === "string")) {
+    res
+      .status(STATUSES.BAD_REQUEST.code)
+      .send(`${STATUSES.BAD_REQUEST.message} | image no exist on body`);
+  } else {
+    req.params.parsed = {
+      body,
+      format,
+      height,
+      width,
+    };
+
+    next();
+  }
+}

--- a/src/api/v1/postPictureController.ts
+++ b/src/api/v1/postPictureController.ts
@@ -1,11 +1,16 @@
 import { STATUSES } from "../../utils/httpStatuses";
 
+// Controller url path
+export const postPictureUrl = "/postPicture/:format/:w/:h";
+
+// Main controller method
 export function postPictureController(req, res) {
   const params = req.params.parsed;
 
   res.status(STATUSES.SUCCESS.code).json(params);
 }
 
+// Controller middlewares
 export function postPictureValidationMiddleware(req, res, next) {
   const body = req.body;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const APP_PORT: number = parseInt( process.env.PORT || '8080' );
 
 app.use(bodyParser.json());
 
+// ATTACH CONTROLLERS VERSIONS
 app.use("/v1/", apiV1Controllers);
 
 app.listen(APP_PORT, (): void => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as bodyParser from "body-parser";
 import { config } from "dotenv";
 import * as express from "express";
 
@@ -8,6 +9,8 @@ export const app = express();
 
 // tslint:disable-next-line
 const APP_PORT: number = parseInt( process.env.PORT || '8080' );
+
+app.use(bodyParser.json());
 
 app.use("/v1/", apiV1Controllers);
 

--- a/src/utils/httpStatuses.ts
+++ b/src/utils/httpStatuses.ts
@@ -1,0 +1,10 @@
+export const STATUSES = {
+  BAD_REQUEST: {
+    code: 400,
+    message: "Bad request",
+  },
+  SUCCESS: {
+    code: 200,
+    message: "Everything is OK",
+  },
+};


### PR DESCRIPTION
Closes #5

Enpoint is designed to take an image in a form `base64` `string` as a pody param:

```
{
	"image": BASE64_IMAGE_STRING
}
```